### PR TITLE
Support static linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,33 @@
   "BSD 3-Clause License (Revised)"
 
 A binding to `libffi`, allowing C functions of types only known at runtime to be called from Haskell.
+
+# Notes on static linking
+
+This library makes the somewhat unusual choice to link against `libffi`
+statically by default rather than dynamically. This is because GHC bundles its
+own dynamically linked `libffi`, and moreover, there is no guarantee that the
+version of `libffi` that GHC bundles will match the version of `libffi` that
+your operating system provides. When these versions don't match, any executable
+that depends on the `libffi` library will likely crash at runtime with an error
+message like this:
+
+```
+error while loading shared libraries: libffi.so.7: cannot open shared object file: No such file or directory
+```
+
+For more information, see
+[GHC#15397](https://gitlab.haskell.org/ghc/ghc/-/issues/15397). We work around
+this issue by forcing the use of static linking in the `libffi` library (using
+`-fstatic` flag) on operating systems that support it. If you really want to
+dynamically link against `libffi`, compile this library with `-f-static`.
+
+Note that the `-fstatic` flag is not supported on macOS because macOS's linker
+does not support either `-Bstatic -lffi `-Bdynamic` or `-l:libffi.a`, which are
+the only two ways that we are aware of for forcing the use of static linking
+without hard-coding the full path to `libffi.a`. It turns out that `-fstatic`
+is not even required on macOS since macOS will statically link against `libffi`
+for you, even if you do not explicitly ask for it. We are not quite sure why
+this happens (see [issue #1](https://github.com/remiturk/libffi/issues/1) for
+more on this), but it has the fortunate side effect of avoiding GHC#15397
+altogether on macOS.

--- a/libffi.cabal
+++ b/libffi.cabal
@@ -32,6 +32,10 @@ source-repository head
   type:                git
   location:            https://github.com/remiturk/libffi
 
+flag static
+  description:      Force static linking against @libffi@
+  default:          True
+
 library
   build-depends:       base >= 3 && < 5, bytestring
   exposed-modules:     Foreign.LibFFI,
@@ -39,6 +43,22 @@ library
                        Foreign.LibFFI.Types,
                        Foreign.LibFFI.FFITypes,
                        Foreign.LibFFI.Internal
-  pkgconfig-depends:   libffi
-  extra-libraries:     ffi
-  includes:            ffi.h ffitarget.h
+  if flag(static)
+    -- It would be shorter to just use this:
+    --
+    -- cc-options:        -Wl,-Bstatic -lffi -Wl,-Bdynamic
+    --
+    -- But `cabal check` doesn't like using the -l option in cc-options,
+    -- instead recommending extra-libraries. We really do need to use -l here,
+    -- however, as it is crucial that -lffi appear in between
+    -- -Wl,-Bstatic ... -Wl,-Bdynamic in order for this to work. We use
+    -- ghc-options instead to work around `cabal check`'s pickiness.
+    ghc-options:       -optl-Wl,-Bstatic -optl-Wl,-lffi -optl-Wl,-Bdynamic
+    includes:          ffi.h ffitarget.h
+    if os(darwin)
+      -- libffi already gets statically linked on Darwin when building an
+      -- executable and -Bstatic isn't supported by the linker, so we disable
+      -- the static flag.
+      build-depends:  base < 0 && > 0
+  else
+    pkgconfig-depends: libffi


### PR DESCRIPTION
This patch:

* Adds a `-fstatic` cabal flag that forces the use of static linking against the `libffi` C library. This also includes some documentation in the `README` about why this is necessary to work around GHC issues. This fixes #6.
* Avoids using `extra-libraries` and `includes` stanzas when `-f-static` is configured, as they are implied by the `pkgconfig-depends: libffi` line. This fixes #5.

Co-authored by @qsctr.