### PR TITLE
Add a way to get a `CType`'s size and alignment

### DIFF
--- a/Foreign/LibFFI/Base.hs
+++ b/Foreign/LibFFI/Base.hs
@@ -56,12 +56,11 @@ sizeAndAlignmentOfCType cType = do
   then return (fromIntegral size, fromIntegral alignment)
   else do
     -- The type's size and alignment haven't been initialized
-    -- so we force it with a call to `ffi_get_struct_offsets`.
-    -- When the `offsets` parameter is null, no offsets will be
-    -- returned, instead the type will just be laid out.
-    status <- ffi_get_struct_offsets ffi_default_abi cType nullPtr
+    -- so we force it with a call to `ffi_prep_cif`.
+    status <- allocaBytes sizeOf_cif $ \cif ->
+                ffi_prep_cif cif ffi_default_abi 0 cType nullPtr
     unless (status == ffi_ok) $
-      error "sizeAndAlignmentOfCType: ffi_get_struct_offsets failed"
+      error "sizeAndAlignmentOfCType: ffi_prep_cif failed"
     (size, alignment) <- ffi_type_size_and_alignment cType
     return (fromIntegral size, fromIntegral alignment)
 

--- a/Foreign/LibFFI/Internal.hsc
+++ b/Foreign/LibFFI/Internal.hsc
@@ -36,8 +36,17 @@ init_ffi_type cType cTypes = do
     (#poke ffi_type, type) cType ((#const FFI_TYPE_STRUCT) :: CUShort)
     (#poke ffi_type, elements) cType cTypes
 
+ffi_type_size_and_alignment :: Ptr CType -> IO (CSize, CUShort)
+ffi_type_size_and_alignment cType = do
+  size <- (#peek ffi_type, size) cType
+  alignment <- (#peek ffi_type, alignment) cType
+  return (size, alignment)
+
 foreign import ccall safe ffi_prep_cif
     :: Ptr CIF -> C_ffi_abi -> CUInt -> Ptr CType -> Ptr (Ptr CType) -> IO C_ffi_status
 
 foreign import ccall safe ffi_call
     :: Ptr CIF -> FunPtr a -> Ptr CValue -> Ptr (Ptr CValue) -> IO ()
+
+foreign import ccall safe ffi_get_struct_offsets
+    :: C_ffi_abi -> Ptr CType -> Ptr CSize -> IO C_ffi_status

--- a/Foreign/LibFFI/Internal.hsc
+++ b/Foreign/LibFFI/Internal.hsc
@@ -47,6 +47,3 @@ foreign import ccall safe ffi_prep_cif
 
 foreign import ccall safe ffi_call
     :: Ptr CIF -> FunPtr a -> Ptr CValue -> Ptr (Ptr CValue) -> IO ()
-
-foreign import ccall safe ffi_get_struct_offsets
-    :: C_ffi_abi -> Ptr CType -> Ptr CSize -> IO C_ffi_status


### PR DESCRIPTION
Adds `sizeAndAlignmentOfCType` to `Foreign.LibFFI.Base` which get the size of alignment of the given `CType`.
If those fields are zero, i.e. the `CType` hasn't been laid out with any ABI yet, then it forces the type to get laid out with the default ABI using `ffi_get_struct_offsets`.

Let me know if you prefer a different API or would prefer the library user manually force the `CType` to be laid out instead of it happening implicitly. 